### PR TITLE
Max node crash fix ASL as outlined by DU8BL - Fix #42

### DIFF
--- a/asterisk/apps/app_rpt.c
+++ b/asterisk/apps/app_rpt.c
@@ -24824,8 +24824,7 @@ static int rpt_manager_do_sawstat(struct mansession *ses, const struct message *
 
 static int rpt_manager_do_xstat(struct mansession *ses, const struct message *m, char *str)
 {
-	int i,j;
-	char ns;
+	int i,j,ns;
 	char lbuf[MAXLINKLIST],*strs[MAXLINKLIST];
 	struct rpt *myrpt;
 	struct ast_var_t *newvariable;

--- a/asterisk/apps/app_rpt.c
+++ b/asterisk/apps/app_rpt.c
@@ -7201,8 +7201,7 @@ static int rpt_do_lstats(int fd, int argc, char *argv[])
 
 static int rpt_do_xnode(int fd, int argc, char *argv[])
 {
-	int i,j;
-	char ns;
+	int i,j,ns;
 	char lbuf[MAXLINKLIST],*strs[MAXLINKLIST];
 	struct rpt *myrpt;
 	struct ast_var_t *newvariable;
@@ -7441,8 +7440,7 @@ static int rpt_do_xnode(int fd, int argc, char *argv[])
 
 static int rpt_do_nodes(int fd, int argc, char *argv[])
 {
-	int i,j;
-	char ns;
+	int i,j,ns;
 	char lbuf[MAXLINKLIST],*strs[MAXLINKLIST];
 	struct rpt *myrpt;
 	if(argc != 3)


### PR DESCRIPTION
This will fix the max node crash non specic to hub or standalone nodes. When connected to heavy hubs. DU8BL fix